### PR TITLE
fix for python3 (basestring not defined)

### DIFF
--- a/kinet2pcb/kinet2pcb.py
+++ b/kinet2pcb/kinet2pcb.py
@@ -18,7 +18,7 @@ from .pckg_info import __version__
 
 def rmv_quotes(s):
     """Remove starting and ending quotes from a string."""
-    if not isinstance(s, basestring):
+    if not isinstance(s, str):
         return s
 
     mtch = re.match(r'^\s*"(.*)"\s*$', s)


### PR DESCRIPTION
fixed issue when running with python3: `NameError: name 'basestring' is not defined`
`isinstance(s, str)` would work for both python2&3