### PR TITLE
Connect all pads of the same number in a footprint to the matching net 

### DIFF
--- a/kinet2pcb/kinet2pcb.py
+++ b/kinet2pcb/kinet2pcb.py
@@ -232,6 +232,7 @@ def kinet2pcb(netlist_origin, brd_filename, fp_lib_dirs=None):
         fp.SetParent(brd)
         fp.SetReference(part.ref)
         fp.SetValue(part.value)
+        fp.SetFPIDAsString(part.footprint)
         # fp.SetTimeStamp(part.sheetpath.tstamps)
         try:
             # Newer PCBNEW API.

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 minversion = 3.15
-envlist = py{27,36,37,38,39,310,311}
+envlist = py{27,36,37,38,39,310,311,312}
 skip_missing_interpreters = true
 # The following makes Python 2.7 and 3.6 work.
 requires = virtualenv==20.21
 
-[testenv:py{27,36,37,38,39,310,311}]
+[testenv:py{27,36,37,38,39,310,311,312}]
 isolated_build = True
 passenv = *
 extras = testing


### PR DESCRIPTION
Added iterator to connect all pads of the same number to a given net. This mimics the behaviour of the GUI editor. Otherwise parts like via stitched mounting holes only have a single pad connected (such as one of several vias).