### PR TITLE
Update kinet2pcb.py

### DIFF
--- a/kinet2pcb/kinet2pcb.py
+++ b/kinet2pcb/kinet2pcb.py
@@ -311,8 +311,7 @@ def kinet2pcb(netlist_origin, brd_filename, fp_lib_dirs=None):
         fp_lib, fp_name = part.footprint.split(":")
 
         # Get the URI of the library directory.
-        lib_uri = fp_libs[fp_lib]
-
+        lib_uri = os.path.expandvars(fp_libs[fp_lib])
         # Create a module from the footprint file.
         fp = pcbnew.FootprintLoad(lib_uri, fp_name)
         if not fp:


### PR DESCRIPTION
It obtains the expanded path reflecting the URI containing environment variables.

KICAD9_FOOTPRINT_DIR="/usr/share/kicad/footprints" "${KICAD9_FOOTPRINT_DIR}/Connector_PinSocket_2.54mm.pretty" => "/usr/share/kicad/footprints/Connector_PinSocket_2.54mm.pretty"