### PR TITLE
lib match out name is '"KiCad"', need try remove quotes

### DIFF
--- a/kinet2pcb/kinet2pcb.py
+++ b/kinet2pcb/kinet2pcb.py
@@ -130,6 +130,7 @@ class LibURIs(dict):
                 lib,
                 flags=re.IGNORECASE | re.VERBOSE,
             )[0]
+            type_ = rmv_quotes(type_)
             if type_.lower() != "kicad":
                 continue
 


### PR DESCRIPTION
example fp-lib-table line 
(lib (name "Audio_Module")(type "KiCad")(uri "${KICAD9_FOOTPRINT_DIR}/Audio_Module.pretty")(options "")(descr "Audio Module footprints"))